### PR TITLE
Fixed Website Title

### DIFF
--- a/fe-public/src/pages/index.astro
+++ b/fe-public/src/pages/index.astro
@@ -10,7 +10,7 @@ import DarkMode from "../components/DarkMode.astro";
     <DarkMode />
     <div id="container">
         <MatrixBackground length=17 amplitude=5 period=40 falloff=2 flip="false"></MatrixBackground>
-        <h1 id="header" class="text-5xl text-center h-200 top-16">AI and<br>Robotics<br>Club</h1>
+        <h1 id="header" class="text-5xl text-center h-200 top-16">Robotics<br>and AI<br>Club</h1>
         <h2 id="header-join" class="text-3xl text-center top-32">JOIN</h2>
     </div>
     <Scoreboard></Scoreboard>


### PR DESCRIPTION
The club is called the robotics and ai club not ai and robotics
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Refactor: Updated the name of the club on the homepage. The original name 'AI and Robotics Club' has been changed to 'Robotics and AI Club'. This change is purely cosmetic and does not affect the functionality of the website."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->